### PR TITLE
Add FastAPI barcode upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # Inventario-Servitae
-Repositorio para llevar un control de Bodegas
+
+Repositorio para llevar un control de Bodegas.
+
+## Backend de carga de códigos de barras
+
+Se proporciona un pequeño API construido con **FastAPI** que permite subir imágenes de códigos de barras.
+
+### Instalación de dependencias
+
+```bash
+pip install -r requirements.txt
+```
+
+### Ejecución del servidor
+
+```bash
+uvicorn app:app --reload
+```
+
+### Endpoint de subida
+
+```
+POST /upload/{marketplace}
+```
+
+Envía el archivo de imagen como `form-data` usando el campo `file`. La extensión debe ser `.jpg`, `.jpeg`, `.bmp`, `.webp` o `.png`.
+
+Las imágenes se guardan en `uploads/<marketplace>/` y el nombre final contiene el nombre del marketplace para evitar mezcla entre canales.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pathlib import Path
+import shutil
+import time
+
+app = FastAPI()
+
+ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".bmp", ".webp", ".png"}
+BASE_UPLOADS_DIR = Path("uploads")
+
+@app.post("/upload/{marketplace}")
+async def upload_barcode(marketplace: str, file: UploadFile = File(...)):
+    ext = Path(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=400, detail="Unsupported file type")
+
+    dest_dir = BASE_UPLOADS_DIR / marketplace
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = int(time.time() * 1000)
+    dest_file = dest_dir / f"{marketplace}_{timestamp}{ext}"
+
+    with dest_file.open("wb") as buffer:
+        shutil.copyfileobj(file.file, buffer)
+
+    return {"marketplace": marketplace, "filename": dest_file.name}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart


### PR DESCRIPTION
## Summary
- implement `/upload/{marketplace}` endpoint using FastAPI
- store files inside `uploads/<marketplace>/` named with the marketplace prefix
- document how to install dependencies and run the server
- add `requirements.txt`

## Testing
- `python3 -m py_compile app.py`
- `uvicorn app:app --port 8000 --no-access-log &`
- `curl -X POST -F "file=@sample.jpg" http://127.0.0.1:8000/upload/amazon`

------
https://chatgpt.com/codex/tasks/task_e_68716f0727dc8323af66ba491e64f3d2