### PR TITLE
Fix README formatting and align with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,6 @@
 Repositorio para llevar un control de Bodegas
 
 
-## Marketplace API
-
-Un pequeño servicio Flask permite administrar los marketplaces.
-
-### Instalación
-
-```bash
-pip install -r requirements.txt
-```
-
-### Uso
-
-```bash
-python app.py
-```
-
-El servidor expondrá las siguientes rutas:
-
-- `GET /marketplaces` devuelve todos los marketplaces.
-- `POST /marketplaces/add` agrega un nuevo marketplace con un cuerpo JSON `{"name": "nombre"}` y crea su carpeta de carga en `uploads/<nombre>`.
-
-La aplicación también sirve un frontend sencillo en la raíz (`/`) que muestra la lista de marketplaces y permite añadir nuevos dinámicamente.
-=======
 ## Barcode generation
 
 Run the application with Flask to generate barcodes:


### PR DESCRIPTION
## Summary
- clean up README
- document the existing barcode endpoint only

## Testing
- `python -m py_compile app.py` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_687173fed84c832382aeaa9974414559